### PR TITLE
Run `rbenv vars` not `rbenv-vars`

### DIFF
--- a/etc/rbenv.d/exec/rbenv-vars.bash
+++ b/etc/rbenv.d/exec/rbenv-vars.bash
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-eval "$(rbenv-vars)"
+eval "$(rbenv vars)"
 


### PR DESCRIPTION
This change was required for variables to be exported in terminal for me using Ruby 2.2.0 and OS X 10.10.

Not sure if this breaks anything on other versions? Please advise.